### PR TITLE
Support custom error responses (statusCodes, values) when DENYing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,8 +75,8 @@ short-circuits with a `403` status.
 All bouncers are individual functions, that accept a `req` and a `res` argument
 (this is the same `req` that an express middleware receives), and return a
 promise.  If the promise resolves to anything other than `SecureRouter.DENY`,
-`SecureRouter.AUTHENTICATE`, or `SecureRouter.AUTHORIZE`, the bouncer is
-ignored.
+`SecureRouter.AUTHENTICATE`, `SecureRouter.AUTHORIZE`, or the result of
+`SecureRouter.denyWith()`, the bouncer is ignored.
 
 Example:
 
@@ -85,9 +85,22 @@ const bouncer = function (req, res) {
   getSecurityClearanceLevel(req.user.id)
   .then(function (level) {
     if (level === 'TOP SECRET') return SecureRouter.AUTHORIZE;
+    else return SecureRouter.denyWith({
+      statusCode: 404,
+      payload: 'Nothing to see here, move along.'
+    });
   });
 }
 ```
+
+### denyWith()
+
+Returns a bouncer response that will cause the bouncer to deny the request,
+and will edit the response to whatever you specify.
+
+- `statusCode`: `Number`, changes the statusCode of the response.
+- `payload`: `Object`, is sent directly to the client in the body of the
+  request.
 
 ### Defining bouncers on individual endpoints
 

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,8 @@ router.secureEndpoint({
   method: 'GET',
   path: '/the-crown-jewels',
   bouncers: [
-    ((req) => if (req.user) return 'AUTHENTICATE'),
-    ((req) => if (req.user.isRoyalty) return 'AUTHORIZE'),
+    ((req) => if (req.user) return SecureRouter.AUTHENTICATE),
+    ((req) => if (req.user.isRoyalty) return SecureRouter.AUTHORIZE),
   ],
   middleware (req, res) {
     req.send(theCrownJewels)
@@ -39,9 +39,9 @@ router.secureEndpoint({
 secretRouter = router.secureSubpath({
   path: '/secrets',
   bouncers: [
-    ((req) => if (req.user) return 'AUTHENTICATE'),
-    ((req) => if (req.user.classification === 'MI6') return 'AUTHORIZE'),
-    ((req) => if (req.user.number === '006') return 'DENY'),
+    ((req) => if (req.user) return SecureRouter.AUTHENTICATE),
+    ((req) => if (req.user.classification === 'MI6') return SecureRouter.AUTHORIZE),
+    ((req) => if (req.user.number === '006') return return SecureRouter.DENY),
   ],
 });
 
@@ -74,8 +74,9 @@ short-circuits with a `403` status.
 
 All bouncers are individual functions, that accept a `req` and a `res` argument
 (this is the same `req` that an express middleware receives), and return a
-promise.  If the promise resolves to anything other than `DENY`,
-`AUTHENTICATE`, or `AUTHORIZE`, the bouncer is ignored.
+promise.  If the promise resolves to anything other than `SecureRouter.DENY`,
+`SecureRouter.AUTHENTICATE`, or `SecureRouter.AUTHORIZE`, the bouncer is
+ignored.
 
 Example:
 
@@ -83,7 +84,7 @@ Example:
 const bouncer = function (req, res) {
   getSecurityClearanceLevel(req.user.id)
   .then(function (level) {
-    if (level === 'TOP SECRET') return 'AUTHORIZE';
+    if (level === 'TOP SECRET') return SecureRouter.AUTHORIZE;
   });
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -12,22 +12,38 @@ export default class Router extends BaseRouter {
     this.pathDefinitions = [];
   }
 
+  static denyWith (params) {
+    return _.assign({}, Router.DENY, params);
+  }
+
   bounceRequests () {
     const router = this;
     router.use(function (req, res, next) {
       const parsedUrl = url.parse(req.url);
       router.resolveCustomSecurity(req, res, parsedUrl.pathname)
       .then(function (results) {
-        function someResultsMatch (test) {
-          return _.some(results, (result) => result === test);
-        }
-        function noResultsMatch (test) {
-          return _.every(results, (result) => result !== test);
+        function match (result, expectedValue) {
+          return _.isObject(result) && result.value === expectedValue;
         }
 
-        if (someResultsMatch(Router.DENY)) return res.sendStatus(401);
-        if (noResultsMatch(Router.AUTHENTICATE)) return res.sendStatus(401);
-        if (noResultsMatch(Router.AUTHORIZE)) return res.sendStatus(403);
+        function someResultsMatch (expectedValue) {
+          return _.some(results, (result) => match(result, expectedValue));
+        }
+        function noResultsMatch (expectedValue) {
+          return _.every(results, (result) => !match(result, expectedValue));
+        }
+
+        if (someResultsMatch(DENY)) {
+          const denyResults = _.filter(results, (result) => match(result, DENY));
+          const statusCodes = _(denyResults).map('statusCode').uniq().compact().sort().value();
+          res.status(statusCodes.length > 0 ? statusCodes[0] : 401);
+
+          const payloads = _(denyResults).map('payload').uniq().compact().sort().value();
+          return res.send(payloads[0]);
+        }
+
+        if (noResultsMatch(AUTHENTICATE)) return res.sendStatus(401);
+        if (noResultsMatch(AUTHORIZE)) return res.sendStatus(403);
         return next();
       });
     });
@@ -143,9 +159,13 @@ export default class Router extends BaseRouter {
   }
 }
 
-Router.AUTHORIZE = 'AUTHORIZE';
-Router.AUTHENTICATE = 'AUTHENTICATE';
-Router.DENY = 'DENY';
+const AUTHORIZE = 'AUTHORIZE';
+const AUTHENTICATE = 'AUTHENTICATE';
+const DENY = 'DENY';
+
+Router.AUTHORIZE = {value: AUTHORIZE};
+Router.AUTHENTICATE = {value: AUTHENTICATE};
+Router.DENY = {value: DENY};
 
 function createPathDefinition (definition) {
   return _.defaults({}, definition, {

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,9 @@ export default class Router extends BaseRouter {
           return _.every(results, (result) => result !== test);
         }
 
-        if (someResultsMatch('DENY')) return res.sendStatus(401);
-        if (noResultsMatch('AUTHENTICATE')) return res.sendStatus(401);
-        if (noResultsMatch('AUTHORIZE')) return res.sendStatus(403);
+        if (someResultsMatch(Router.DENY)) return res.sendStatus(401);
+        if (noResultsMatch(Router.AUTHENTICATE)) return res.sendStatus(401);
+        if (noResultsMatch(Router.AUTHORIZE)) return res.sendStatus(403);
         return next();
       });
     });
@@ -142,6 +142,10 @@ export default class Router extends BaseRouter {
     return {pathDefinition: null, matchedUrlSegment: ''};
   }
 }
+
+Router.AUTHORIZE = 'AUTHORIZE';
+Router.AUTHENTICATE = 'AUTHENTICATE';
+Router.DENY = 'DENY';
 
 function createPathDefinition (definition) {
   return _.defaults({}, definition, {

--- a/test.js
+++ b/test.js
@@ -29,8 +29,8 @@ describe('use()', function () {
       method: 'GET',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -47,8 +47,8 @@ describe('secureEndpoint()', function () {
       method: 'GET',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -64,8 +64,8 @@ describe('secureEndpoint()', function () {
       method: 'POST',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -81,8 +81,8 @@ describe('secureEndpoint()', function () {
       method: 'PUT',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -98,8 +98,8 @@ describe('secureEndpoint()', function () {
       method: 'DELETE',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -115,8 +115,8 @@ describe('secureEndpoint()', function () {
       method: 'HEAD',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -132,8 +132,8 @@ describe('secureEndpoint()', function () {
       method: 'GET',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -148,8 +148,8 @@ describe('secureSubpath()', function () {
     router.secureSubpath({
       path: '/sub',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
     })
     .get('/foo', (req, res) => res.sendStatus(200));
@@ -166,8 +166,8 @@ describe('secureSubpath()', function () {
     router.secureSubpath({
       path: '/sub',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
     })
     .use('/subsub', subSubRouter);
@@ -182,8 +182,8 @@ describe('secureSubpath()', function () {
     subRouter.secureSubpath({
       path: '/subsub',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
       ],
     })
     .get('/foo', (req, res) => res.sendStatus(200));
@@ -197,8 +197,8 @@ describe('secureSubpath()', function () {
 describe('bouncer()', function () {
   it('allows you to arbitrarily add bouncers to routers', function () {
     const router = buildRouter();
-    router.bouncer(_.constant('AUTHENTICATE'));
-    router.bouncer(_.constant('AUTHORIZE'));
+    router.bouncer(_.constant(Router.AUTHENTICATE));
+    router.bouncer(_.constant(Router.AUTHORIZE));
     router.get('/foo', (req, res) => res.sendStatus(200));
     return withRunningServer(router)
     .then(() => expectRequest('GET', '/foo').toReturnCode(200));
@@ -227,9 +227,9 @@ describe('allowing and denying', function () {
       method: 'GET',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
-        _.constant('DENY'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
+        _.constant(Router.DENY),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -243,8 +243,8 @@ describe('allowing and denying', function () {
       method: 'GET',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHENTICATE),
+        _.constant(Router.AUTHORIZE),
         _.constant(),
       ],
       middleware: (req, res) => res.sendStatus(200),
@@ -260,7 +260,7 @@ describe('allowing and denying', function () {
       path: '/foo',
       bouncers: [
         _.constant(),
-        _.constant('AUTHORIZE'),
+        _.constant(Router.AUTHORIZE),
       ],
       middleware: (req, res) => res.sendStatus(200),
     });
@@ -274,7 +274,7 @@ describe('allowing and denying', function () {
       method: 'GET',
       path: '/foo',
       bouncers: [
-        _.constant('AUTHENTICATE'),
+        _.constant(Router.AUTHENTICATE),
         _.constant(),
       ],
       middleware: (req, res) => res.sendStatus(200),
@@ -290,9 +290,9 @@ describe('bouncer arguments', function () {
     let url;
     router.bouncer(function (req) {
       url = req.url;
-      return 'AUTHENTICATE';
+      return Router.AUTHENTICATE;
     });
-    router.bouncer(_.constant('AUTHORIZE'));
+    router.bouncer(_.constant(Router.AUTHORIZE));
     return withRunningServer(router)
     .then(() => expectRequest('GET', '/foo').toReturnCode(404))
     .then(function () {
@@ -304,9 +304,9 @@ describe('bouncer arguments', function () {
     const router = buildRouter();
     router.bouncer(function (req, res) {
       res.set('x-foo', 'bar');
-      return 'AUTHENTICATE';
+      return Router.AUTHENTICATE;
     });
-    router.bouncer(_.constant('AUTHORIZE'));
+    router.bouncer(_.constant(Router.AUTHORIZE));
     return withRunningServer(router)
     .then(() => expectRequest('GET', '/foo').toHaveHeader('x-foo', 'bar'));
   });


### PR DESCRIPTION
Bouncer functions
=================

All bouncers are individual functions, that accept a `req` and a `res` argument (this is the same `req` that an express middleware receives), and return a promise.  If the promise resolves to anything other than `SecureRouter.DENY`, `SecureRouter.AUTHENTICATE`, `SecureRouter.AUTHORIZE`, or the result of `SecureRouter.denyWith()`, the bouncer is ignored.

Example:

```js
const bouncer = function (req, res) {
  getSecurityClearanceLevel(req.user.id)
  .then(function (level) {
    if (level === 'TOP SECRET') return SecureRouter.AUTHORIZE;
    else return SecureRouter.denyWith({
      statusCode: 404,
      payload: 'Nothing to see here, move along.'
    });
  });
}
```

denyWith()
=========

Returns a bouncer response that will cause the bouncer to deny the request, and will edit the response to whatever you specify.

- `statusCode`: `Number`, changes the statusCode of the response.
- `payload`: `Object`, is sent directly to the client in the body of the request.