### PR TITLE
match path definitions from most to least specific

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,10 @@ export default class Router extends BaseRouter {
 
   getPathDefinitionMatching (urlSegment, method) {
     let matches, hasMethod;
+    /* start with most specific path definition */
+    this.pathDefinitions.sort((a, b) =>
+      b.path.split('/').length - a.path.split('/').length
+    );
     for (const pathDefinition of this.pathDefinitions) {
       matches = pathDefinition.regexp.exec(urlSegment);
       hasMethod = _.isNil(method) || _.includes(pathDefinition.methods, method);


### PR DESCRIPTION
When we get to a "leaf router" (i.e. a router that has no innerRouters), we should
match pathDefinitions from most specific to least specific. Otherwise, we end up
applying bouncers that aren't for the path we're resolving!

E.g.

if `POST /foo/bar` and `POST /foo` are secure endpoints, first try to match the request to `POST /foo/bar`.

@serhalp
cc @demands (for when you're back!)