### PR TITLE
fixes sorting issue that caused the wrong bouncers to be applied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
+sudo: required
+dist: trusty
+
 language: node_js
 node_js:
   - '6'
   - '5'
   - '4'
   - '4.2.6'
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ export default class Router extends BaseRouter {
     let matches, hasMethod;
     /* start with most specific path definition */
     this.pathDefinitions.sort((a, b) =>
-      b.path.split('/').length - a.path.split('/').length
+      _.compact(b.path.split('/')).length - _.compact(a.path.split('/')).length
     );
     for (const pathDefinition of this.pathDefinitions) {
       matches = pathDefinition.regexp.exec(urlSegment);

--- a/test.js
+++ b/test.js
@@ -157,7 +157,7 @@ describe('secureEndpoint()', function () {
     });
     fooRouter.secureEndpoint({
       method: 'POST',
-      path: '/:id/destroy',
+      path: '/:id',
       bouncers: [
         _.constant(Router.AUTHENTICATE),
         _.constant(Router.denyWith({statusCode: 403})),
@@ -167,7 +167,7 @@ describe('secureEndpoint()', function () {
 
     return withRunningServer(router)
       .then(() => expectRequest('POST', '/foo').toReturnCode(200))
-      .then(() => expectRequest('POST', '/foo/123/destroy').toReturnCode(403));
+      .then(() => expectRequest('POST', '/foo/123').toReturnCode(403));
   });
 });
 


### PR DESCRIPTION
see the test I changed, but given two paths `/` and `/foo`, when routing `/foo` we were preferring the routing definition for `/` (even though `/foo` is more specific).

```
'/'.split('/').length; //=> 2 (['', ''])
'/foo'.split('/').length; //=> 2 (['', 'foo'])
```

/reviewplz @makebbekus 