### PR TITLE
Add optional debug output via debug module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.1",
+    "debug": "^2.6.0",
     "lodash": "^4.13.1",
     "path-to-regexp": "^1.5.3",
     "router": "^1.1.4"


### PR DESCRIPTION
Run secure-router's tests or any module/app using secure-router with the env variable `DEBUG=secure-router` to see helpful debug-level console output:

![screen shot 2017-01-09 at 5 33 07 pm](https://cloud.githubusercontent.com/assets/1377702/21790516/bae8f052-d691-11e6-8de3-69be707013aa.png)