### PR TITLE
handle uncaught exceptions in bouncer middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 - If there is more than one bouncer that `DENY`s, the first one that is encountered
   is the one that will determine the response of the request.
+  
+- **BEWARE** - Bouncers are now expected to return a promise that resolves with an object
+  that has a `middleware` property. Versions of `goodeggs-authentication-tokens` [<10.0.0](https://github.com/goodeggs/goodeggs-authentication-tokens/blob/master/CHANGELOG.md#v1000)
+  use an earlier version of `sercure-router` in which `Router.denyWith` returns an object without the property.
+  When you bump `secure-router` be sure to also bump `goodeggs-authentication-tokens`.
+  
+  Note that `goodeggs-server`@14.0.0 uses `secure-router@3.0.0`.
+  
 
 # [v2.0.0](https://github.com/goodeggs/secure-router/compare/v1.2.1...v2.0.0)
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ export default class Router extends BaseRouter {
               try {
                 middleware(req, res, callback);
               } catch (err) {
+                debug('DENY middleware threw a synchronous error', err.stack);
                 callback(err);
               }
             },

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,13 @@ export default class Router extends BaseRouter {
           // TODO(@max) sort here???
           async.eachSeries(
             _.map(denyResults, 'middleware'),
-            (middleware, callback) => middleware(req, res, callback),
+            (middleware, callback) => {
+              try {
+                middleware(req, res, callback);
+              } catch (err) {
+                callback(err);
+              }
+            },
             next
           );
           return;

--- a/test.js
+++ b/test.js
@@ -440,6 +440,26 @@ describe('custom denials with Router.denyWith()', function () {
       });
     });
   });
+
+  it('returns a 500 for an invalid bouncer (e.g. secure-router@2.1.1. Router.DENY)', function () {
+    const router = buildRouter();
+
+    router.bouncer(function () {
+      // secure-router@2.1.1 returns this kind of bouncer if you use `Router.denyWith`
+      return Promise.resolve({value: 'DENY', statusCode: 401});
+    });
+
+    router.secureEndpoint({
+      method: 'GET',
+      path: '/bar',
+      middleware: (req, res) => res.send(200),
+    });
+
+    return withRunningServer(router)
+    .then(function () {
+      return expectRequest('GET', '/bar').toReturnCode(500);
+    });
+  });
 });
 
 


### PR DESCRIPTION
Because we weren't try/catching the call and a synchronous error was being thrown
in async code (`async.eachSeries`), eventually the response would hang untli the
client closed the connection. Unintuitively, the response code would be 200 because
it was never over-written.

Additionally, now if a bouncer middleware itself throws a synchronous error, this
will also be handled. In both of these cases a 500 is now returned immediately.

We discovered this due to some of our apps using multiple versions of secure-router
(one in goodeggs-server and one directly). This lead to bouncers being setup with
an old pattern that didn't include a `middleware` function to return the error.

pair w/ @bobzoller