### PR TITLE
Fix two bugs in req.matchedRoutes: final segment duplication & trailing slashes.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ export default class Router extends BaseRouter {
     if (req.matchedRoutes == null) req.matchedRoutes = [];
     req.__route = (req.__route || '') + path;
 
-    if (!_.isEmpty(path)) {
+    if (!_.isEmpty(path) && path !== _.last(req.matchedRoutes)) {
       req.matchedRoutes.push(path);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -152,6 +152,7 @@ export default class Router extends BaseRouter {
     let offset = this.stack.length;
     BaseRouter.prototype.use.apply(this, arguments);
 
+    // Inspired by https://github.com/expressjs/express/issues/2879#issuecomment-180088895
     /* so that in our monkey patch of process_params, we can know about the
      * path of this part of the route */
     if (pathIsString) {
@@ -162,6 +163,7 @@ export default class Router extends BaseRouter {
     }
   }
 
+  // Inspired by https://github.com/expressjs/express/issues/2879#issuecomment-180088895
   // eslint-disable-next-line camelcase
   process_params (layer, called, req) {
     const path =

--- a/src/index.js
+++ b/src/index.js
@@ -157,11 +157,7 @@ export default class Router extends BaseRouter {
     if (pathIsString) {
       for (; offset < this.stack.length; offset++) {
         const layer = this.stack[offset];
-        // I'm not sure if my check for `fast_slash` is the way to go here
-        // But if I don't check for it, each stack element will add a slash to the path
-        if (layer && layer.regexp && !layer.regexp.fast_slash) {
-          layer.__mountpath = path;
-        }
+        layer.__mountpath = path;
       }
     }
   }
@@ -177,8 +173,9 @@ export default class Router extends BaseRouter {
     if (req.matchedRoutes == null) req.matchedRoutes = [];
     req.__route = (req.__route || '') + path;
 
-    if (!_.isEmpty(path) && path !== _.last(req.matchedRoutes)) {
-      req.matchedRoutes.push(path);
+    const normalizedPath = path.endsWith('/') ? path.substr(0, path.length - 1) : path;
+    if (!_.isEmpty(normalizedPath) && normalizedPath !== _.last(req.matchedRoutes)) {
+      req.matchedRoutes.push(normalizedPath);
     }
 
     return BaseRouter.prototype.process_params.apply(this, arguments);


### PR DESCRIPTION
### [Fix duplicated path segments](https://github.com/goodeggs/secure-router/commit/edc09374a8d4e4b31201a693e01b25e9cfba8414)

For some reason, if a request gets handled by one or more error middlewares, our monkey-patched `process_params` gets called for each error middleware, which appends a duplicate of the last segment of the path each time. For example, we were seeing `['/v1', '/lots', '/:_id/set_expiration_day', '/:_id/set_expiration_day', '/:_id/set_expiration_day', '/:_id/set_expiration_day', '/:_id/set_expiration_day', '/:_id/set_expiration_day', '/:_id/set_expiration_day']`.

This works around this by detecting duplicate segments and ignoring them... Doesn't feel great but it unblocks us. Unfortunately this leaves an edge case: if a route were to intentionally have consecutive identical segments, they would get collapsed. For example a top-level router `/foo/:id`
then a child router `/foo:/:id`. This doesn't seem likely to ever come up. 🤷‍♂️ 


### [Normalize presence of trailing slashes](https://github.com/goodeggs/secure-router/commit/b3e9dbb2011461e2406683dd0b794f1207dd9a44)

Our `use()` monkey-patch was only being exercised by... well, calls to `use()`. Calls to `get()`, `post()`, etc. were not exercising the clumsy code that skips over '/' paths.

:pear: with @murkey 

cc @demands 